### PR TITLE
feat: Implement navigation and home screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,8 @@ dependencies {
     implementation(libs.androidx.compose.ui.test)
     implementation(libs.androidx.material3)
     implementation("androidx.compose.material:material-icons-extended")
+    implementation(libs.androidx.navigation.runtime.ktx)
+    implementation(libs.androidx.navigation.compose)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/myapplication/HomeScreen.kt
+++ b/app/src/main/java/com/example/myapplication/HomeScreen.kt
@@ -1,0 +1,45 @@
+package com.example.myapplication
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+
+@Composable
+fun HomeScreen(navController: NavController) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(text = stringResource(R.string.pantalla_inicial), modifier = Modifier.padding(bottom = 32.dp))
+
+        Button(
+            onClick = { navController.navigate("login") },
+            modifier = Modifier.fillMaxWidth(0.7f)
+        ) {
+            Text(stringResource(R.string.ir_a_login))
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Button(
+            onClick = { navController.navigate("listAll") },
+            modifier = Modifier.fillMaxWidth(0.7f)
+        ) {
+            Text(stringResource(R.string.ir_a_lista_de_enfermeros))
+        }
+
+        Button(
+            onClick = { navController.navigate("search") },
+            modifier = Modifier.fillMaxWidth(0.7f)
+        ) {
+            Text(stringResource(R.string.ir_a_b_squeda))
+        }
+    }
+}

--- a/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -4,13 +4,13 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import com.example.myapplication.ui.theme.MyApplicationTheme
 
 class MainActivity : ComponentActivity() {
@@ -18,7 +18,26 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            SearchScreen()
+            val navController = rememberNavController()
+
+            NavHost(navController = navController, startDestination = "home") {
+
+                composable("home") {
+                    HomeScreen(navController)
+                }
+
+                composable("listAll") {
+                    ListScreen(navController)
+                }
+
+//                composable("login") {
+//
+//                }
+
+//                composable("search") {
+//
+//                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/myapplication/NurseListScreen.kt
+++ b/app/src/main/java/com/example/myapplication/NurseListScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -18,11 +19,23 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Badge
 import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.ExitToApp
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -34,33 +47,94 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SearchScreen() {
+fun ListScreen(navController: NavHostController) {
+
+    var expanded by remember { mutableStateOf(false) }
+
     val allNurses = listOf(
-        Nurse(1, "Pol", "Carvajal", "pol123", "pol.carvajal","pol@hospital.com"),
-        Nurse(2, "Ana", "García", "ana_g", "ana.garcia","ana.garcia@hospital.com"),
-        Nurse(3, "Biel", "Laguna", "biel_l", "biel.laguna","biel@hospital.com"),
-        Nurse(4, "Laura", "Torres", "laura.t", "laura.torres","laura@hospital.com"),
-        Nurse(5, "Carlos", "Ruiz", "charlie", "carlos.ruiz","carlos@hospital.com")
+        Nurse(1, "Pol", "Carvajal", "pol123", "pol.carvajal", "pol@hospital.com"),
+        Nurse(2, "Ana", "García", "ana_g", "ana.garcia", "ana.garcia@hospital.com"),
+        Nurse(3, "Biel", "Laguna", "biel_l", "biel.laguna", "biel@hospital.com"),
+        Nurse(4, "Laura", "Torres", "laura.t", "laura.torres", "laura@hospital.com"),
+        Nurse(5, "Carlos", "Ruiz", "charlie", "carlos.ruiz", "carlos@hospital.com")
     )
 
-    Column(
+    Scaffold(
         modifier = Modifier
             .fillMaxSize()
-            .padding(20.dp)
-    ) {
-        Text(
-            text = stringResource(R.string.nurse_list),
-            style = MaterialTheme.typography.headlineMedium,
-            modifier = Modifier.padding(bottom = 16.dp)
-        )
-        LazyColumn(
-            contentPadding = PaddingValues(bottom = 24.dp),
-            verticalArrangement = Arrangement.spacedBy(7.dp),
+            .statusBarsPadding(),
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(text = stringResource(R.string.nurse_list))
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = colorResource(id = R.color.nurse_icon),
+                    titleContentColor = colorResource(R.color.white),
+                    actionIconContentColor = colorResource(R.color.white)
+                ),
+                actions = {
+                    IconButton(onClick = { expanded = true }) {
+                        Icon(
+                            imageVector = Icons.Default.MoreVert,
+                            contentDescription = stringResource(id = R.string.nurse_message_icon)
+                        )
+                    }
+
+                    DropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { expanded = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("Inicio") },
+                            onClick = {
+                                expanded = false
+                                navController.navigate("home") {
+                                    popUpTo("home") { inclusive = true }
+                                }
+                            },
+                            leadingIcon = { Icon(Icons.Default.Home, stringResource(id = R.string.nurse_message_icon)) }
+                        )
+
+                        // Opción 2: LOGIN
+                        DropdownMenuItem(
+                            text = { Text("Login") },
+                            onClick = {
+                                expanded = false
+                                navController.navigate("login")
+                            },
+                            leadingIcon = { Icon(Icons.Default.ExitToApp, stringResource(R.string.nurse_message_icon)) }
+                        )
+
+                        DropdownMenuItem(
+                            text = { Text("Buscar") },
+                            onClick = {
+                                navController.navigate("search")
+                            },
+                            leadingIcon = { Icon(Icons.Default.Search, stringResource(R.string.nurse_message_icon)) }
+                        )
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = 16.dp)
         ) {
-            items(allNurses) {
-                NurseItem(nurse = it)
+            LazyColumn(
+                contentPadding = PaddingValues(top = 16.dp, bottom = 24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                items(allNurses) { nurse ->
+                    NurseItem(nurse = nurse)
+                }
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,8 @@
     <string name="app_name">My Application</string>
     <string name="nurse_list">Listado de Enfermeros</string>
     <string name="nurse_message_icon">Icono No encontrado</string>
+    <string name="pantalla_inicial">Pantalla Inicial</string>
+    <string name="ir_a_login">Ir a Login</string>
+    <string name="ir_a_lista_de_enfermeros">Ir a Lista de Enfermeros</string>
+    <string name="ir_a_b_squeda">Ir a Búsqueda</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,8 @@ activityCompose = "1.8.0"
 composeBom = "2024.09.00"
 uiTest = "1.9.4"
 material3 = "1.4.0"
+navigationRuntimeKtx = "2.9.6"
+navigationCompose = "2.9.6"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -28,6 +30,8 @@ androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-te
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-compose-ui-test = { group = "androidx.compose.ui", name = "ui-test", version.ref = "uiTest" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
+androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navigation-runtime-ktx", version.ref = "navigationRuntimeKtx" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This commit introduces Jetpack Navigation Compose to structure the app's flow and adds a new home screen.

- **Navigation:**
  - Adds `navigation-compose` and `navigation-runtime-ktx` dependencies.
  - Configures a `NavHost` in `MainActivity` with routes for "home" and "listAll".

- **Home Screen:**
  - Creates a new `HomeScreen.kt` with navigation buttons for "Login", "Nurse List", and "Search".
  - Adds corresponding string resources for the home screen buttons.

- **List Screen:**
  - Renames `SearchScreen` to `ListScreen` and adapts it to use the `NavController`.
  - Implements a `Scaffold` with a `TopAppBar` that includes a dropdown menu for navigation to Home, Login, and Search.
  - Updates UI with status bar padding and new Material icons.